### PR TITLE
feat : 주간날씨 렌더링 => setInterval 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
         "react-table": "^7.8.0",
+        "reactjs-crontab": "^4.5.0",
         "styled-components": "^5.3.6",
         "web-vitals": "^2.1.4"
       }
@@ -14855,6 +14856,17 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/reactjs-crontab": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/reactjs-crontab/-/reactjs-crontab-4.5.0.tgz",
+      "integrity": "sha512-22xqIeTvrMFGisicrih5jhBahKSXnuYEGUjkbvbdUnrowdcbHrXF+f8uZziBH/7YylSDySssgvtXdmMa+JaI7g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -28081,6 +28093,12 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
+    },
+    "reactjs-crontab": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/reactjs-crontab/-/reactjs-crontab-4.5.0.tgz",
+      "integrity": "sha512-22xqIeTvrMFGisicrih5jhBahKSXnuYEGUjkbvbdUnrowdcbHrXF+f8uZziBH/7YylSDySssgvtXdmMa+JaI7g==",
+      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "react-table": "^7.8.0",
+    "reactjs-crontab": "^4.5.0",
     "styled-components": "^5.3.6",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/weather/WeeklyWeather.js
+++ b/src/components/weather/WeeklyWeather.js
@@ -40,8 +40,9 @@ const WeeklyWeather = ({ weekly }) => {
       <span>{hour[idx]}시</span>
     </WrapList>
   ));
-  console.log(twoDayList);
-  console.log(oneDayList);
+
+  console.log(postList);
+  console.log(twoPostList);
 
   return (
     <>

--- a/src/pages/Loading.js
+++ b/src/pages/Loading.js
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { API_KEY } from '../config';
 import { useNavigate } from 'react-router-dom';
+// import Crontab from 'reactjs-crontab';
 
 const loadingImg = process.env.PUBLIC_URL + '/images/loading.gif';
 
@@ -33,7 +34,7 @@ const Loading = () => {
   };
 
   //주간 날씨 가져오기
-  const getWeeklyWeather = async (lat, lon, result) => {
+  const getWeeklyWeather = setInterval(async (lat, lon, result) => {
     const weeklyUrl = `http://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&appid=${API_KEY}&units=metric&lang=kr`;
 
     try {
@@ -41,7 +42,6 @@ const Loading = () => {
         response.json()
       );
       navigate('/home', {
-
         replace: false,
         state: {
           result,
@@ -51,16 +51,30 @@ const Loading = () => {
     } catch (error) {
       console.log(error);
     }
-  };
+  }, 86400);
+
+  // const tasks = [
+  //   {
+  //     fn: getWeeklyWeather,
+  //     id: '2',
+  //     config:
+  //       '0 0,1,2,4,3,5,6,7,9,8,10,11,12,19,18,22,21,20,23,17,16,15,13 * * *',
+  //     name: '',
+  //     description: '',
+  //   },
+  // ];
+
   // api fetching 후 페이지 이동
   useEffect(() => {
     getCurrentLocation();
   }, []);
 
   return (
+    // <Crontab tasks={tasks} timeZone="Asia/Seoul" dashboard={{ hidden: false }}>
     <LoadingContainer>
       <img src={loadingImg} alt="loading" />
     </LoadingContainer>
+    // </Crontab>
   );
 };
 


### PR DESCRIPTION
# Summary
 
주간날씨 렌더링 => setInterval 추가
 

## Component Image 

<img width="973" alt="스크린샷 2022-12-03 오전 10 31 13" src="https://user-images.githubusercontent.com/100752008/205416199-38dabda1-8c18-467f-8b31-4a38ce0883ae.png">


# Details

setInterval 사용했으나 api자체의 딜레이 오류도 있을뿐더러
우리가 갖고자하는 데이터를 받아올수 없음으로
리액트 크론텝을 조금 더 공부해서 적용해보고
크론텝이 적용이 안될시 기온에 따른 시간도 같이 패칭하여
자연스럽게 흘러가는 구조로 변경해요!ㅠㅠ(아쉽지만 우리의 최선....)