### PR TITLE
feat : weeklyWeather 시간 수정

### DIFF
--- a/src/components/weather/WeeklyWeather.js
+++ b/src/components/weather/WeeklyWeather.js
@@ -10,8 +10,16 @@ const WeeklyWeather = ({ weekly }) => {
 
   //모레 날씨 리스트
   const twoDayList = weekly.list.slice(14, 23);
+  console.log(twoDayList);
+  // console.log(twoDayList[0].dt_txt);
 
-  const hour = [0, 3, 6, 9, 12, 15, 18, 21, 24];
+  // const SliceLength = twoDayList.length;
+
+  // console.log(Slice.slice(11, 13));
+
+  // console.log(Object.keys(twoDayList).slice(0));
+
+  // const hour = [0, 3, 6, 9, 12, 15, 18, 21];
 
   //내일 날씨 리스트 렌더링
   const postList = oneDayList.map((data, idx) => (
@@ -22,7 +30,7 @@ const WeeklyWeather = ({ weekly }) => {
         src={`http://openweathermap.org/img/wn/${data.weather[0].icon}@2x.png`}
         alt="weather icon"
       />
-      <span>{hour[idx]}시</span>
+      <span>{data.dt_txt.slice(11, 13).replace('0', '')}시</span>
     </WrapList>
   ));
 
@@ -35,7 +43,7 @@ const WeeklyWeather = ({ weekly }) => {
         src={`http://openweathermap.org/img/wn/${data.weather[0].icon}@2x.png`}
         alt="weather icon"
       />
-      <span>{hour[idx]}시</span>
+      <span>{data.dt_txt.slice(11, 13).replace('0', '')}시</span>
     </WrapList>
   ));
 

--- a/src/components/weather/WeeklyWeather.js
+++ b/src/components/weather/WeeklyWeather.js
@@ -6,10 +6,10 @@ import { TiWeatherSunny, TiWeatherShower } from 'react-icons/ti';
 
 const WeeklyWeather = ({ weekly }) => {
   //내일 날씨 리스트
-  const oneDayList = weekly.list.slice(6, 15);
+  const oneDayList = weekly.list.slice(6, 14);
 
   //모레 날씨 리스트
-  const twoDayList = weekly.list.slice(14, 23);
+  const twoDayList = weekly.list.slice(14, 22);
   console.log(twoDayList);
   // console.log(twoDayList[0].dt_txt);
 

--- a/src/pages/Loading.js
+++ b/src/pages/Loading.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { API_KEY } from '../config';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getCityName } from '../utils/city';
-// import Crontab from 'reactjs-crontab';
 
 const loadingImg = process.env.PUBLIC_URL + '/images/loading.gif';
 
@@ -77,17 +76,7 @@ const Loading = () => {
       console.log(error);
     }
   };
-
-  // const tasks = [
-  //   {
-  //     fn: getWeeklyWeather,
-  //     id: '2',
-  //     config:
-  //       '0 0,1,2,4,3,5,6,7,9,8,10,11,12,19,18,22,21,20,23,17,16,15,13 * * *',
-  //     name: '',
-  //     description: '',
-  //   },
-  // ];
+  console.log(getWeeklyWeather);
 
   // api fetching 후 페이지 이동
   useEffect(() => {
@@ -102,11 +91,9 @@ const Loading = () => {
   }, []);
 
   return (
-    // <Crontab tasks={tasks} timeZone="Asia/Seoul" dashboard={{ hidden: false }}>
     <LoadingContainer>
       <img src={loadingImg} alt="loading" />
     </LoadingContainer>
-    // </Crontab>
   );
 };
 


### PR DESCRIPTION
# Summary

weeklyWeather 시간 수정

## Component Image 

![캡처xxxx](https://user-images.githubusercontent.com/100752008/206197691-5679dd24-73a6-4c77-8f18-2a4c4dd138d5.PNG)

# Details

hour 배열 index 값으로 줘서 나타냈던 Weekly 시간 구성을
API 로직 내부에서 time 값을 따와서 나타내는걸로 변경했어요!

react-crontab은 Every Time으로 돌렸는데 적용이 안돼서(에러 확인도 불가)
일단 api 내부에서 경로를 따서 필요한 부분만 Slice하여 시간을 따왔고
"00시", "06시", "09시" 등 앞에 0이 붙은 숫자들은 보기 좋지않아 replace로 ""값으로 반환 처리하여
"0시","6시", "9시"처럼 보이는 UI를 만들었습니다!

그래서 시간 렌더링 순서가 조금 뒤죽박죽이긴 하지만,,, 
API 한계로 인해 기존에 있던 시간과 온도가 맞지 않는 현상은 해결했으니.. (만족합니다...ㅎㅎ) 